### PR TITLE
minimium viable protobuf serving

### DIFF
--- a/mapproxy/client/http.py
+++ b/mapproxy/client/http.py
@@ -176,8 +176,16 @@ class HTTPClient(object):
     def open_image(self, url, data=None):
         resp = self.open(url, data=data)
         if 'content-type' in resp.headers:
-            if not resp.headers['content-type'].lower().startswith('image'):
-                raise HTTPClientError('response is not an image: (%s)' % (resp.read()))
+	    content_type = resp.headers['content-type'].lower()
+	    img_content_type = content_type.startswith('image')
+	    protobuf_content_type = content_type.endswith('x-protobuf')
+
+            if not img_content_type and not protobuf_content_type:
+                raise HTTPClientError(
+		    'response is not a valid content-type: (%s)' % (content_type,)
+		)
+
+        # TODO: return TileSource if application/x-protobuf
         return ImageSource(resp)
 
 def auth_data_from_url(url):

--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -1096,7 +1096,7 @@ class CacheConfiguration(ConfigurationBase):
 
     @memoize
     def image_opts(self):
-        from mapproxy.image.opts import ImageFormat
+        from mapproxy.image.opts import ImageFormat, MVTFormat
 
         format = None
         if 'format' not in self.conf.get('image', {}):
@@ -1105,6 +1105,8 @@ class CacheConfiguration(ConfigurationBase):
         if image_opts.format is None:
             if format is not None and format.startswith('image/'):
                 image_opts.format = ImageFormat(format)
+	    elif format is not None and format.endswith('/pbf'):
+                image_opts.format = MVTFormat('application/pbf') # THIS IS WHAT SET FORMAT
             else:
                 image_opts.format = ImageFormat('image/png')
         return image_opts

--- a/mapproxy/image/opts.py
+++ b/mapproxy/image/opts.py
@@ -59,6 +59,43 @@ class ImageOptions(object):
     def copy(self):
         return copy.copy(self)
 
+class MVTFormat(str):
+    def __new__(cls, value, *args, **keywargs):
+        if isinstance(value, ImageFormat):
+            return value
+        return str.__new__(cls, value)
+
+    @property
+    def mime_type(self):
+        if self.startswith('application/'):
+            return self
+        return 'application/' + self
+
+    @property
+    def ext(self):
+        ext = self
+        if '/' in ext:
+            ext = ext.split('/', 1)[1]
+        if ';' in ext:
+            ext = ext.split(';', 1)[0]
+
+        return ext.strip()
+
+    def __eq__(self, other):
+        if isinstance(other, string_type):
+            other = ImageFormat(other)
+        elif not isinstance(other, ImageFormat):
+            return NotImplemented
+
+        return self.ext == other.ext
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
 class ImageFormat(str):
     def __new__(cls, value, *args, **keywargs):
         if isinstance(value, ImageFormat):

--- a/mapproxy/service/tile.py
+++ b/mapproxy/service/tile.py
@@ -42,6 +42,7 @@ log = logging.getLogger(__name__)
 from mapproxy.template import template_loader, bunch
 get_template = template_loader(__name__, 'templates')
 
+
 class TileServer(Server):
     """
     A Tile Server. Supports strict TMS and non-TMS requests. The difference is the
@@ -287,7 +288,6 @@ class TileLayer(object):
             raise RequestError('invalid format (%s). this tile set only supports (%s)'
                                % (tile_request.format, self.format), request=tile_request,
                                code='InvalidParameterValue')
-
         tile_coord = self._internal_tile_coord(tile_request, use_profiles=use_profiles)
 
         coverage_intersects = False


### PR DESCRIPTION
⚠️ **very early development branch**

I've narrowed down some changes which get mapproxy working with tegola.  It works with the tegola preview tool and successfully proxies and caches at different scales.

In general mapproxy primitives seem to heavily assume raster images, so a lot more refactoring work may be necessary to get this upstream.

I point the tegola preview HTML file layer `url` value to http://localhost:8080/tms/1.0.0/terranodo/webmercator/{z}/{x}/{y}.pbf
Here is my `mapproxy.yaml`:

Note: I sometimes use `application/pbf` instead of `application/x-protobuf` due to current design constraints within mapproxy.

```
# -------------------------------
# MapProxy example configuration.
# -------------------------------
#
# This is a minimal MapProxy configuration.
# See full_example.yaml and the documentation for more options.
#

# Starts the following services:
# Demo:
#     http://localhost:8080/demo
# WMS:
#     capabilities: http://localhost:8080/service?REQUEST=GetCapabilities
# WMTS:
#     capabilities: http://localhost:8080/wmts/1.0.0/WMTSCapabilities.xml
#     first tile: http://localhost:8080/wmts/osm/webmercator/0/0/0.png
# Tile service (compatible with OSM/etc.)
#     first tile: http://localhost:8080/tiles/osm/webmercator/0/0/0.png
# TMS:
#     note: TMS is not compatible with OSM/Google Maps/etc.
#     fist tile: http://localhost:8080/tms/1.0.0/osm/webmercator/0/0/0.png
# KML:
#     initial doc: http://localhost:8080/kml/osm/webmercator

services:
  demo:
  tms:
    use_grid_names: true
    # origin for /tiles service
    origin: 'nw'
  kml:
      use_grid_names: true
  wmts:
  wms:
    md:
      title: MapProxy WMS Proxy
      abstract: This is a minimal MapProxy example.

layers:
  - name: terranodo
    title: Omniscale OSM WMS - osm.omniscale.net
    sources: [terranodo_cache]

caches:
  terranodo_cache:
    grids: [webmercator]
    sources: [terranodo]
    format: application/pbf

sources:
  terranodo:
    type: tile
    url: http://localhost:9090/maps/world_borders/%(z)s/%(x)s/%(y)s.vector.pbf?debug=true
    image:
        formats:
          pbf:
            format: application/pbf
            mode: P
            transparent: false
grids:
    webmercator:
        base: GLOBAL_WEBMERCATOR

globals:
```
